### PR TITLE
Add Redirects capsule and middleware

### DIFF
--- a/src/Http/Middleware/RedirectMiddleware.php
+++ b/src/Http/Middleware/RedirectMiddleware.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace TwillRedirects\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use TwillRedirects\Twill\Capsules\Redirects\Models\Redirect;
+
+class RedirectMiddleware
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $redirects = Cache::rememberForever('twill_redirects', function () {
+            return optional(Redirect::first())->redirects ?? [];
+        });
+
+        $path = '/' . ltrim($request->path(), '/');
+
+        foreach ($redirects as $rule) {
+            $from = $rule['from'] ?? null;
+            $to = $rule['to'] ?? null;
+            $status = (int) ($rule['statuscode'] ?? 302);
+
+            if ($from && $this->matches($path, $from)) {
+                Log::info('Redirect match', ['from' => $path, 'to' => $to, 'status' => $status]);
+                return redirect($to, $status);
+            }
+        }
+
+        return $next($request);
+    }
+
+    private function matches(string $path, string $pattern): bool
+    {
+        $pattern = '/' . ltrim($pattern, '/');
+
+        if (str_ends_with($pattern, '*')) {
+            return str_starts_with($path, rtrim($pattern, '*'));
+        }
+
+        return rtrim($path, '/') === rtrim($pattern, '/');
+    }
+}

--- a/src/Twill/Capsules/Redirects/Http/Controllers/RedirectController.php
+++ b/src/Twill/Capsules/Redirects/Http/Controllers/RedirectController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace TwillRedirects\Twill\Capsules\Redirects\Http\Controllers;
+
+use A17\Twill\Http\Controllers\Admin\SingletonModuleController as BaseModuleController;
+use A17\Twill\Services\Forms\Fields\Input;
+use A17\Twill\Services\Forms\Form;
+use A17\Twill\Services\Forms\Fields\Repeater;
+use A17\Twill\Models\Contracts\TwillModelContract;
+
+class RedirectController extends BaseModuleController
+{
+    protected string $moduleName = 'redirects';
+
+    protected function getForm(TwillModelContract $model): Form
+    {
+        $form = parent::getForm($model);
+
+        $form->add(
+            Input::make()->name('title')->label('Title')
+        );
+
+        $form->add(
+            Repeater::make()->name('redirects')->label('Redirects')
+        );
+
+        return $form;
+    }
+}

--- a/src/Twill/Capsules/Redirects/Http/Requests/RedirectRequest.php
+++ b/src/Twill/Capsules/Redirects/Http/Requests/RedirectRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace TwillRedirects\Twill\Capsules\Redirects\Http\Requests;
+
+use A17\Twill\Http\Requests\Admin\Request;
+
+class RedirectRequest extends Request
+{
+    public function rulesForCreate(): array
+    {
+        return $this->rules();
+    }
+
+    public function rulesForUpdate(): array
+    {
+        return $this->rules();
+    }
+
+    protected function rules(): array
+    {
+        return [
+            'title' => 'required|string|max:255',
+            'redirects' => 'nullable|array',
+            'redirects.*.from' => 'required_with:redirects|string',
+            'redirects.*.to' => 'required_with:redirects|string',
+            'redirects.*.statuscode' => 'nullable|integer',
+        ];
+    }
+}

--- a/src/Twill/Capsules/Redirects/Models/Redirect.php
+++ b/src/Twill/Capsules/Redirects/Models/Redirect.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace TwillRedirects\Twill\Capsules\Redirects\Models;
+
+use A17\Twill\Models\Model;
+
+class Redirect extends Model
+{
+    protected $fillable = [
+        'published',
+        'title',
+        'redirects',
+    ];
+
+    protected $casts = [
+        'redirects' => 'array',
+    ];
+}

--- a/src/Twill/Capsules/Redirects/Repositories/RedirectRepository.php
+++ b/src/Twill/Capsules/Redirects/Repositories/RedirectRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TwillRedirects\Twill\Capsules\Redirects\Repositories;
+
+use A17\Twill\Repositories\Behaviors\HandleJsonRepeaters;
+use A17\Twill\Repositories\ModuleRepository;
+use TwillRedirects\Twill\Capsules\Redirects\Models\Redirect;
+
+class RedirectRepository extends ModuleRepository
+{
+    use HandleJsonRepeaters;
+
+    protected array $jsonRepeaters = ['redirects'];
+
+    public function __construct(Redirect $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/src/Twill/Capsules/Redirects/database/migrations/2024_01_01_000000_create_redirects_table.php
+++ b/src/Twill/Capsules/Redirects/database/migrations/2024_01_01_000000_create_redirects_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::create('redirects', function (Blueprint $table) {
+            createDefaultTableFields($table);
+            $table->string('title')->nullable();
+            $table->json('redirects')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('redirects');
+    }
+};

--- a/src/Twill/Capsules/Redirects/resources/views/twill/redirects/form.blade.php
+++ b/src/Twill/Capsules/Redirects/resources/views/twill/redirects/form.blade.php
@@ -1,0 +1,10 @@
+@extends('twill::layouts.form')
+
+@section('contentFields')
+    @formField('input', [
+        'name' => 'title',
+        'label' => 'Title',
+    ])
+
+    @formField('repeater', ['type' => 'redirects'])
+@stop

--- a/src/Twill/Capsules/Redirects/resources/views/twill/repeaters/redirect.blade.php
+++ b/src/Twill/Capsules/Redirects/resources/views/twill/repeaters/redirect.blade.php
@@ -1,0 +1,12 @@
+@twillRepeaterTitle('Redirect')
+@twillRepeaterTrigger('Add redirect rule')
+@twillRepeaterGroup('twill')
+
+<x-twill::input name="from" label="From"/>
+<x-twill::input name="to" label="To"/>
+<x-twill::select name="statuscode" label="Status code" :options="[
+    ['value' => 301, 'label' => '301'],
+    ['value' => 302, 'label' => '302'],
+    ['value' => 307, 'label' => '307'],
+    ['value' => 308, 'label' => '308'],
+]"/>

--- a/src/Twill/Capsules/Redirects/routes/twill.php
+++ b/src/Twill/Capsules/Redirects/routes/twill.php
@@ -1,0 +1,5 @@
+<?php
+
+use A17\Twill\Facades\TwillRoutes;
+
+TwillRoutes::singleton('redirect');

--- a/src/TwillRedirectsServiceProvider.php
+++ b/src/TwillRedirectsServiceProvider.php
@@ -3,7 +3,16 @@
 namespace TwillRedirects;
 
 use A17\Twill\TwillPackageServiceProvider;
+use Illuminate\Support\Facades\Route;
+use TwillRedirects\Http\Middleware\RedirectMiddleware;
 
 class TwillRedirectsServiceProvider extends TwillPackageServiceProvider
 {
+    public function boot(): void
+    {
+        $this->registerCapsules('Capsules');
+        $this->loadMigrationsFrom(__DIR__ . '/Twill/Capsules/Redirects/database/migrations');
+
+        Route::aliasMiddleware('twill.redirects', RedirectMiddleware::class);
+    }
 }


### PR DESCRIPTION
## Summary
- add Redirect capsule model, repository, controller and request
- provide admin form and repeater views
- create migration and Twill admin routes
- register capsule and middleware
- implement middleware for front-end redirects

## Testing
- `composer validate --no-check-all --strict` *(fails: composer not installed)*
- `php -l src/Twill/Capsules/Redirects/Models/Redirect.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68528d1cde2c832fb06c3c08a2695e3d