### PR TITLE
Fix redirect middleware docs and clarify fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,17 @@ Add the service provider and middleware alias to your `config/twill.php` if not 
 
 Laravel 11 no longer uses the `Http\Kernel` class for middleware
 registration. Instead, middleware is configured in `bootstrap/app.php`.
-Define the alias and append it to the `web` middleware group within the
-`withMiddleware` closure:
+Because redirect rules may apply to URLs that don't match any defined
+route, the middleware should run before route resolution. Register it in
+the global middleware stack within the `withMiddleware` closure:
 
 ```php
 use TwillRedirects\Http\Middleware\RedirectMiddleware;
 use Illuminate\Foundation\Configuration\Middleware;
 
 ->withMiddleware(function (Middleware $middleware) {
-    $middleware->alias([
-        'twill.redirects' => RedirectMiddleware::class,
-    ]);
-
-    $middleware->web(append: [
-        'twill.redirects',
+    $middleware->global(prepend: [
+        RedirectMiddleware::class,
     ]);
 })
 ```

--- a/src/Http/Middleware/RedirectMiddleware.php
+++ b/src/Http/Middleware/RedirectMiddleware.php
@@ -10,6 +10,11 @@ use TwillRedirects\Twill\Capsules\Redirects\Models\Redirect;
 
 class RedirectMiddleware
 {
+    /**
+     * Check the requested URL against the configured redirect rules and
+     * perform a redirect when a match is found. If no rule matches the
+     * request, control is passed to the next middleware/route handler.
+     */
     public function handle(Request $request, Closure $next)
     {
         $redirects = Cache::rememberForever('twill_redirects', function () {


### PR DESCRIPTION
## Summary
- clarify that `RedirectMiddleware` should be added to the global middleware stack
- document global middleware usage in README
- add documentation comment explaining fallback behaviour in `RedirectMiddleware`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852cbb2ae50832f8962cd6d9276eca5