### PR TITLE
Fix wildcard redirect base path handling

### DIFF
--- a/src/Http/Middleware/RedirectMiddleware.php
+++ b/src/Http/Middleware/RedirectMiddleware.php
@@ -42,7 +42,13 @@ class RedirectMiddleware
         $pattern = '/' . ltrim($pattern, '/');
 
         if (str_ends_with($pattern, '*')) {
-            return str_starts_with($path, rtrim($pattern, '*'));
+            $base = rtrim($pattern, '*');
+
+            if (rtrim($path, '/') === rtrim($base, '/')) {
+                return true;
+            }
+
+            return str_starts_with($path, $base);
         }
 
         return rtrim($path, '/') === rtrim($pattern, '/');


### PR DESCRIPTION
## Summary
- account for wildcard redirect when request path equals the base

## Testing
- `composer validate --no-check-all && composer install --no-interaction` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6853c5a4179c832f9c1441da462fee45