### PR TITLE
Fix redirect cache refresh

### DIFF
--- a/src/Twill/Capsules/Redirects/Models/Redirect.php
+++ b/src/Twill/Capsules/Redirects/Models/Redirect.php
@@ -3,6 +3,7 @@
 namespace TwillRedirects\Twill\Capsules\Redirects\Models;
 
 use A17\Twill\Models\Model;
+use Illuminate\Support\Facades\Cache;
 
 class Redirect extends Model
 {
@@ -15,4 +16,10 @@ class Redirect extends Model
     protected $casts = [
         'redirects' => 'array',
     ];
+
+    protected static function booted(): void
+    {
+        static::saved(fn () => Cache::forget('twill_redirects'));
+        static::deleted(fn () => Cache::forget('twill_redirects'));
+    }
 }


### PR DESCRIPTION
## Summary
- flush cached redirects when a redirect model is saved or deleted

## Testing
- `find src -name '*.php' -print0 | xargs -0 -n1 php -l`
- `composer install --ignore-platform-req=ext-simplexml` *(fails: ext-dom missing and php version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6853c83d3cec832fb4d4d568e6c18e45